### PR TITLE
feat: refresh portraits when equipping inventory items

### DIFF
--- a/app/src/api/inventory.js
+++ b/app/src/api/inventory.js
@@ -1,0 +1,5 @@
+import api from './client'
+
+export async function equipItem(inventoryId, equipped) {
+  return api.patch(`/characters/inventory/${inventoryId}`, { equipped })
+}

--- a/app/src/pages/characters/CharacterDetail.jsx
+++ b/app/src/pages/characters/CharacterDetail.jsx
@@ -15,13 +15,28 @@ export default function CharacterDetail(){
     api.post(`/characters/${id}/attributes`, {}).then(r=>setAttrs(r.data)).catch(()=>{})
   },[id])
   if (!ch) return <div>Cargando…</div>
+
+  const portrait = ch.Creature?.portrait
+  const portraitUrl = portrait?.meta?.secureUrl
+
   return (
     <div className="space-y-3">
       <div className="card">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">{ch.Creature?.name}</h2>
-            <div className="text-sm opacity-70">Nivel {ch.Creature?.level}</div>
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="w-28 h-28 border border-slate-700 rounded overflow-hidden flex items-center justify-center bg-slate-900">
+              {portraitUrl ? (
+                <img src={portraitUrl} alt={`Retrato de ${ch.Creature?.name ?? 'personaje'}`} className="w-full h-full object-cover" />
+              ) : portrait ? (
+                <div className="text-xs text-center px-2">Retrato en proceso…</div>
+              ) : (
+                <div className="text-xs text-center px-2 opacity-70">Sin retrato</div>
+              )}
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold">{ch.Creature?.name}</h2>
+              <div className="text-sm opacity-70">Nivel {ch.Creature?.level}</div>
+            </div>
           </div>
           <div className="flex gap-2">
             <Link to={`/personajes/${id}/talentos`} className="btn">Talentos</Link>

--- a/app/src/pages/characters/Inventory.jsx
+++ b/app/src/pages/characters/Inventory.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import api from '../../api/client'
+import { equipItem } from '../../api/inventory'
 
 export default function Inventory(){
   const { id } = useParams()
@@ -8,21 +9,142 @@ export default function Inventory(){
   const [all, setAll] = useState([])
   const [sel, setSel] = useState('')
   const [qty, setQty] = useState(1)
+  const [itemStatus, setItemStatus] = useState({})
+  const [portraitUrl, setPortraitUrl] = useState(null)
+  const [portraitError, setPortraitError] = useState('')
+  const [portraitLoading, setPortraitLoading] = useState(true)
+  const isMounted = useRef(true)
+
+  useEffect(()=>{
+    return ()=>{ isMounted.current = false }
+  },[])
 
   const load = async()=>{
-    const inv = await api.get(`/characters/${id}/inventory`); setItems(inv.data)
-    const ai = await api.get('/items'); setAll(ai.data)
+    try {
+      const inv = await api.get(`/characters/${id}/inventory`)
+      if (isMounted.current) setItems(inv.data)
+    } catch (error) {
+      console.error('No se pudo cargar el inventario', error)
+    }
+    try {
+      const ai = await api.get('/items')
+      if (isMounted.current) setAll(ai.data)
+    } catch (error) {
+      console.error('No se pudo cargar el catálogo de ítems', error)
+    }
   }
-  useEffect(()=>{ load() },[id])
+
+  const updatePortrait = async (silent = false)=>{
+    if (!silent && isMounted.current) {
+      setPortraitLoading(true)
+      setPortraitError('')
+    }
+    try {
+      const res = await api.get(`/characters/${id}`)
+      const url = res.data?.Creature?.portrait?.meta?.secureUrl ?? null
+      if (isMounted.current) {
+        setPortraitUrl(url)
+        setPortraitError('')
+        if (!silent) setPortraitLoading(false)
+      }
+      return url
+    } catch (error) {
+      console.error('No se pudo obtener el retrato', error)
+      if (isMounted.current) {
+        if (!silent) setPortraitLoading(false)
+        setPortraitError('No se pudo cargar el retrato.')
+      }
+      throw error
+    }
+  }
+
+  useEffect(()=>{
+    if (!isMounted.current) return
+    load()
+    updatePortrait().catch(()=>{})
+  },[id])
+
+  const pollPortraitChange = async (previousUrl)=>{
+    const timeoutMs = 20000
+    const intervalMs = 2000
+    const deadline = Date.now() + timeoutMs
+    let lastError = ''
+    while (Date.now() < deadline) {
+      await new Promise(resolve=>setTimeout(resolve, intervalMs))
+      try {
+        const nextUrl = await updatePortrait(true)
+        if (nextUrl !== previousUrl) {
+          return { changed: true, url: nextUrl }
+        }
+      } catch (error) {
+        lastError = 'Error al refrescar el retrato.'
+      }
+    }
+    return { changed: false, error: lastError }
+  }
 
   const add = async()=>{
     await api.post(`/characters/${id}/inventory`, { itemId: sel, qty: Number(qty)||1 })
     load()
   }
 
+  const toggleEquip = async (inventoryItem)=>{
+    if (itemStatus[inventoryItem.id]?.pending) return
+    const nextValue = !inventoryItem.equipped
+    const prevPortrait = portraitUrl
+    if (isMounted.current) {
+      setItemStatus(prev=>({
+        ...prev,
+        [inventoryItem.id]: { pending: true, message: 'Actualizando retrato…', error: '' }
+      }))
+    }
+    try {
+      await equipItem(inventoryItem.id, nextValue)
+      await load()
+      const result = await pollPortraitChange(prevPortrait)
+      if (!isMounted.current) return
+      if (result.changed) {
+        setItemStatus(prev=>({
+          ...prev,
+          [inventoryItem.id]: { pending: false, message: 'Retrato actualizado.', error: '' }
+        }))
+      } else {
+        const errorMessage = result?.error || 'No se detectó un cambio en el retrato.'
+        setItemStatus(prev=>({
+          ...prev,
+          [inventoryItem.id]: { pending: false, message: errorMessage, error: errorMessage }
+        }))
+      }
+    } catch (error) {
+      console.error('Error al equipar/unequipar el ítem', error)
+      if (!isMounted.current) return
+      setItemStatus(prev=>({
+        ...prev,
+        [inventoryItem.id]: { pending: false, message: 'No se pudo actualizar el ítem.', error: 'No se pudo actualizar el ítem.' }
+      }))
+      updatePortrait(true).catch(()=>{})
+    }
+  }
+
   return (
     <div className="space-y-3">
       <h2 className="text-xl font-semibold">Inventario</h2>
+      <div className="card flex flex-col md:flex-row gap-3 items-center">
+        <div className="flex-1">
+          <div className="font-semibold">Retrato actual</div>
+          {portraitLoading ? (
+            <div className="text-sm opacity-70">Cargando retrato…</div>
+          ) : portraitUrl ? (
+            <div className="mt-2">
+              <img src={portraitUrl} alt="Retrato del personaje" className="w-32 h-32 object-cover rounded" />
+            </div>
+          ) : portraitError ? (
+            <div className="text-sm text-red-400">{portraitError}</div>
+          ) : (
+            <div className="text-sm opacity-70">Sin retrato disponible</div>
+          )}
+        </div>
+      </div>
       <div className="card space-y-2">
         <div className="font-semibold">Agregar</div>
         <div className="grid grid-cols-3 gap-2">
@@ -38,6 +160,20 @@ export default function Inventory(){
             <div key={it.id} className="border border-slate-700 rounded p-3">
               <div className="font-semibold">{it.Item?.name}</div>
               <div className="text-sm opacity-70">x{it.qty}</div>
+              <div className="mt-3 flex flex-col gap-2">
+                <button
+                  className="btn"
+                  disabled={!!itemStatus[it.id]?.pending}
+                  onClick={()=>toggleEquip(it)}
+                >
+                  {it.equipped ? 'Quitar' : 'Equipar'}
+                </button>
+                {itemStatus[it.id]?.message && (
+                  <div className={`text-xs ${itemStatus[it.id]?.error ? 'text-red-400' : 'text-emerald-400'}`}>
+                    {itemStatus[it.id].message}
+                  </div>
+                )}
+              </div>
             </div>
           ))}
           {items.length===0 && <div className="opacity-70">Vacío</div>}


### PR DESCRIPTION
## Summary
- add inventory helper to toggle equipped state via the API
- update the inventory screen with equip controls, portrait polling, and status messaging
- surface the character portrait with placeholders in the character detail view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd9693b8a88329bd45c6ae8a193b2b