### PR TITLE
Add item prompt support across frontend and backend

### DIFF
--- a/app/src/pages/dm/Items.jsx
+++ b/app/src/pages/dm/Items.jsx
@@ -3,10 +3,19 @@ import api from '../../api/client'
 
 export default function Items(){
   const [list, setList] = useState([])
-  const [form, setForm] = useState({ name:'', description:'' })
+  const [form, setForm] = useState({ name:'', description:'', prompt:'' })
   const load = ()=> api.get('/items').then(r=>setList(r.data))
   useEffect(()=>{ load() },[])
-  const create = async()=>{ await api.post('/items', form); setForm({ name:'', description:'' }); load() }
+  const create = async()=>{
+    const payload = {
+      name: form.name,
+      description: form.description,
+      meta: { prompt: form.prompt }
+    }
+    await api.post('/items', payload)
+    setForm({ name:'', description:'', prompt:'' })
+    load()
+  }
   const del = async(id)=>{ await api.delete(`/items/${id}`); load() }
   return (
     <div className="space-y-3">
@@ -14,6 +23,7 @@ export default function Items(){
       <div className="card grid md:grid-cols-3 gap-2">
         <input placeholder="Nombre" value={form.name} onChange={e=>setForm(f=>({...f,name:e.target.value}))} />
         <input placeholder="Descripción" value={form.description} onChange={e=>setForm(f=>({...f,description:e.target.value}))} />
+        <textarea className="md:col-span-3" rows={3} placeholder="Prompt de render" value={form.prompt} onChange={e=>setForm(f=>({...f,prompt:e.target.value}))}></textarea>
         <button className="btn" onClick={create} disabled={!form.name}>Crear</button>
       </div>
       <div className="grid md:grid-cols-2 gap-3">
@@ -21,6 +31,10 @@ export default function Items(){
           <div key={i.id} className="card">
             <div className="font-semibold">{i.name}</div>
             <div className="text-sm opacity-70">{i.description}</div>
+            <div className="mt-2 text-xs">
+              <div className="font-semibold">Prompt de render</div>
+              <div className="opacity-80 whitespace-pre-wrap">{i.meta?.prompt || '—'}</div>
+            </div>
             <button className="btn mt-2" onClick={()=>del(i.id)}>Eliminar</button>
           </div>
         ))}

--- a/backend/controllers/itemsController.js
+++ b/backend/controllers/itemsController.js
@@ -1,16 +1,86 @@
 const { Item } = require("../models");
 
+function normalizeMeta(meta) {
+  if (!meta || typeof meta !== "object") return {};
+  return { ...meta };
+}
+
+function extractPrompt(source) {
+  return typeof source === "string" ? source.trim() : undefined;
+}
+
+function mergeMeta(baseMeta, promptValue) {
+  const meta = normalizeMeta(baseMeta);
+  if (promptValue !== undefined) {
+    meta.prompt = promptValue;
+  } else if (meta.prompt === undefined) {
+    meta.prompt = "";
+  }
+  return meta;
+}
+
 exports.createItem = async (req, res, next) => {
-  try { res.json(await Item.create({ name: req.body.name, description: req.body.description || null, iconAssetId: req.body.iconAssetId || null, meta: req.body.meta || {} })); }
-  catch (e) { next(e); }
+  try {
+    const prompt = extractPrompt(req.body.prompt);
+    const meta = mergeMeta(req.body.meta, prompt);
+    const payload = {
+      name: req.body.name,
+      description: req.body.description || null,
+      iconAssetId: req.body.iconAssetId || null,
+      meta,
+    };
+    res.json(await Item.create(payload));
+  } catch (e) {
+    next(e);
+  }
 };
-exports.listItems = async (_req, res, next) => { try { res.json(await Item.findAll()); } catch (e) { next(e); } };
-exports.getItem = async (req, res, next) => { try {
-  const row = await Item.findByPk(req.params.id); if (!row) return res.status(404).json({ error:"Not found" }); res.json(row);
-} catch (e) { next(e); } };
-exports.patchItem = async (req, res, next) => { try {
-  const row = await Item.findByPk(req.params.id); if (!row) return res.status(404).json({ error:"Not found" });
-  for (const k of ["name","description","iconAssetId","meta"]) if (k in req.body) row[k]=req.body[k];
-  await row.save(); res.json(row);
-} catch (e) { next(e); } };
-exports.deleteItem = async (req, res, next) => { try { await Item.destroy({ where:{ id: req.params.id } }); res.json({ ok:true }); } catch (e) { next(e); } };
+
+exports.listItems = async (_req, res, next) => {
+  try {
+    res.json(await Item.findAll());
+  } catch (e) {
+    next(e);
+  }
+};
+
+exports.getItem = async (req, res, next) => {
+  try {
+    const row = await Item.findByPk(req.params.id);
+    if (!row) return res.status(404).json({ error: "Not found" });
+    res.json(row);
+  } catch (e) {
+    next(e);
+  }
+};
+
+exports.patchItem = async (req, res, next) => {
+  try {
+    const row = await Item.findByPk(req.params.id);
+    if (!row) return res.status(404).json({ error: "Not found" });
+
+    for (const key of ["name", "description", "iconAssetId"]) {
+      if (key in req.body) row[key] = req.body[key];
+    }
+
+    const prompt = extractPrompt(req.body.prompt);
+    const shouldUpdateMeta = "meta" in req.body || prompt !== undefined;
+    if (shouldUpdateMeta) {
+      const baseMeta = "meta" in req.body ? req.body.meta : row.meta;
+      row.meta = mergeMeta(baseMeta, prompt);
+    }
+
+    await row.save();
+    res.json(row);
+  } catch (e) {
+    next(e);
+  }
+};
+
+exports.deleteItem = async (req, res, next) => {
+  try {
+    await Item.destroy({ where: { id: req.params.id } });
+    res.json({ ok: true });
+  } catch (e) {
+    next(e);
+  }
+};

--- a/backend/insomnia_dungeonworld.json
+++ b/backend/insomnia_dungeonworld.json
@@ -1377,7 +1377,7 @@
       "description": "Requiere rol DM.",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"name\": \"Pocion de curacion\",\n  \"description\": \"Restaura 2d8 PV\",\n  \"iconAssetId\": \"{{ _.sampleMediaId }}\",\n  \"meta\": {\n    \"rarity\": \"COMMON\"\n  }\n}"
+        "text": "{\n  \"name\": \"Pocion de curacion\",\n  \"description\": \"Restaura 2d8 PV\",\n  \"iconAssetId\": \"{{ _.sampleMediaId }}\",\n  \"meta\": {\n    \"rarity\": \"COMMON\",\n    \"prompt\": \"Frasco diminuto con líquido carmesí que brilla suavemente\"\n  }\n}"
       },
       "headers": [
         {
@@ -1451,7 +1451,7 @@
       "description": "",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"description\": \"Restaura 3d8 PV\",\n  \"meta\": {\n    \"rarity\": \"RARE\"\n  }\n}"
+        "text": "{\n  \"description\": \"Restaura 3d8 PV\",\n  \"meta\": {\n    \"rarity\": \"RARE\",\n    \"prompt\": \"Frasco decorado con filigrana dorada que late con energía arcana\"\n  }\n}"
       },
       "headers": [
         {

--- a/backend/scripts/insomnia_template.json
+++ b/backend/scripts/insomnia_template.json
@@ -1055,7 +1055,7 @@
       "description": "Requiere rol DM.",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"name\": \"Pocion de curacion\",\n  \"description\": \"Restaura 2d8 PV\",\n  \"iconAssetId\": \"{{ _.sampleMediaId }}\",\n  \"meta\": {\n    \"rarity\": \"COMMON\"\n  }\n}"
+        "text": "{\n  \"name\": \"Pocion de curacion\",\n  \"description\": \"Restaura 2d8 PV\",\n  \"iconAssetId\": \"{{ _.sampleMediaId }}\",\n  \"meta\": {\n    \"rarity\": \"COMMON\",\n    \"prompt\": \"Frasco diminuto con líquido carmesí que brilla suavemente\"\n  }\n}"
       },
       "headers": [
         {
@@ -1111,7 +1111,7 @@
       "description": "",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n  \"description\": \"Restaura 3d8 PV\",\n  \"meta\": {\n    \"rarity\": \"RARE\"\n  }\n}"
+        "text": "{\n  \"description\": \"Restaura 3d8 PV\",\n  \"meta\": {\n    \"rarity\": \"RARE\",\n    \"prompt\": \"Frasco decorado con filigrana dorada que late con energía arcana\"\n  }\n}"
       },
       "headers": [
         {


### PR DESCRIPTION
## Summary
- add a render prompt field to the DM items form and show the saved prompt in the listing
- ensure item creation requests send the prompt inside metadata and backend merges flat prompt updates
- seed Insomnia fixtures with example render prompts so metadata is always populated

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd98133a748329b802bcdd3b485f04