### PR TITLE
Enforce character creation limit and add tests

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.7.7",
@@ -17,10 +18,14 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "vitest": "^2.1.1"
   }
 }

--- a/app/src/pages/characters/Characters.jsx
+++ b/app/src/pages/characters/Characters.jsx
@@ -4,12 +4,29 @@ import api from '../../api/client'
 export default function Characters(){
   const [list, setList] = useState([])
   useEffect(()=>{ api.get('/characters/mine').then(r=>setList(r.data)) },[])
+  const hasReachedLimit = list.length >= 3
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">Mis personajes</h2>
-        <Link to="/personajes/crear" className="btn">Crear personaje</Link>
+        {hasReachedLimit ? (
+          <button
+            type="button"
+            className="btn cursor-not-allowed opacity-60"
+            disabled
+            title="Límite de personajes alcanzado"
+          >
+            Crear personaje
+          </button>
+        ) : (
+          <Link to="/personajes/crear" className="btn">Crear personaje</Link>
+        )}
       </div>
+      {hasReachedLimit && (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+          Solo podés tener 3 personajes activos a la vez. Archivá uno para crear uno nuevo.
+        </div>
+      )}
       <div className="grid gap-3 md:grid-cols-2">
         {list.map(ch=>(
           <Link key={ch.id} to={`/personajes/${ch.id}`} className="card block">

--- a/app/src/pages/characters/CreateCharacter.jsx
+++ b/app/src/pages/characters/CreateCharacter.jsx
@@ -40,6 +40,7 @@ export default function CreateCharacter() {
   const [step, setStep] = useState(0)
   const [form, setForm] = useState(INITIAL_FORM)
   const [submitting, setSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -112,6 +113,7 @@ export default function CreateCharacter() {
     event.preventDefault()
     if (!canAdvance || submitting) return
     setSubmitting(true)
+    setErrorMessage('')
     try {
       const trimmedHistory = form.history.trim()
       const trimmedFears = form.fears.trim()
@@ -136,6 +138,12 @@ export default function CreateCharacter() {
       navigate(`/personajes/${data.characterId}/oferta`)
     } catch (error) {
       console.error('Error creating character', error)
+      const message = error?.response?.data?.error
+      if (error?.response?.status === 400 && message) {
+        setErrorMessage(message)
+      } else {
+        setErrorMessage('No se pudo crear el personaje. Intentá nuevamente más tarde.')
+      }
     } finally {
       setSubmitting(false)
     }
@@ -147,6 +155,14 @@ export default function CreateCharacter() {
       <p className="mt-1 text-sm text-slate-300">
         Completá el asistente paso a paso para definir tu nuevo héroe.
       </p>
+      {errorMessage && (
+        <div
+          role="alert"
+          className="mt-4 rounded-lg border border-red-500/50 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+        >
+          {errorMessage}
+        </div>
+      )}
       <div className="mt-6 flex flex-wrap items-center gap-3">
         {STEPS.map((item, index) => {
           const isCompleted = index < step

--- a/app/src/pages/characters/__tests__/Characters.test.jsx
+++ b/app/src/pages/characters/__tests__/Characters.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Characters from '../Characters'
+import { vi } from 'vitest'
+
+const mockGet = vi.fn()
+
+vi.mock('../../../api/client', () => ({
+  default: {
+    get: mockGet,
+  },
+}))
+
+describe('Characters page', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+  })
+
+  it('shows the create button when below the limit', async () => {
+    mockGet.mockResolvedValueOnce({ data: [
+      { id: 1, Creature: { name: 'A', level: 1 } },
+      { id: 2, Creature: { name: 'B', level: 1 } },
+    ] })
+
+    render(
+      <MemoryRouter>
+        <Characters />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled())
+
+    const createLink = screen.getByRole('link', { name: /crear personaje/i })
+    expect(createLink).toBeInTheDocument()
+    expect(createLink).not.toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('disables creation when limit is reached', async () => {
+    mockGet.mockResolvedValueOnce({ data: [
+      { id: 1, Creature: { name: 'A', level: 1 } },
+      { id: 2, Creature: { name: 'B', level: 1 } },
+      { id: 3, Creature: { name: 'C', level: 1 } },
+    ] })
+
+    render(
+      <MemoryRouter>
+        <Characters />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled())
+
+    expect(screen.getByRole('button', { name: /crear personaje/i })).toBeDisabled()
+    expect(
+      screen.getByText(/solo podés tener 3 personajes activos/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/app/src/pages/characters/__tests__/CreateCharacter.test.jsx
+++ b/app/src/pages/characters/__tests__/CreateCharacter.test.jsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import CreateCharacter from '../CreateCharacter'
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('../../../api/client', () => ({
+  default: {
+    get: (...args) => mockGet(...args),
+    post: (...args) => mockPost(...args),
+  },
+}))
+
+describe('CreateCharacter', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPost.mockReset()
+    mockNavigate.mockReset()
+  })
+
+  const setupWizard = async () => {
+    mockGet.mockResolvedValueOnce({ data: [
+      { id: 1, name: 'Humano', description: 'Versátil' },
+    ] })
+    mockGet.mockResolvedValueOnce({ data: [
+      { id: 10, name: 'Guerrero', description: 'Tanque' },
+    ] })
+
+    const user = userEvent.setup()
+    render(<CreateCharacter />)
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+
+    await user.click(screen.getByRole('button', { name: /humano/i }))
+    await user.click(screen.getByRole('button', { name: /siguiente/i }))
+
+    await user.click(screen.getByRole('button', { name: /guerrero/i }))
+    await user.click(screen.getByRole('button', { name: /siguiente/i }))
+
+    await user.type(screen.getByLabelText(/nombre/i), 'Aria')
+    await user.type(screen.getByLabelText(/objetivo a corto plazo/i), 'Recuperar la reliquia')
+    await user.type(screen.getByLabelText(/objetivo a largo plazo/i), 'Derrotar al dragón')
+
+    return user
+  }
+
+  it('navigates after successful creation', async () => {
+    const user = await setupWizard()
+
+    mockPost.mockImplementation((url) => {
+      if (url === '/characters') {
+        return Promise.resolve({ data: { characterId: 7, deckId: 3 } })
+      }
+      return Promise.resolve({ data: {} })
+    })
+
+    await user.click(screen.getByRole('button', { name: /confirmar y crear/i }))
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/characters', expect.any(Object))
+      expect(mockNavigate).toHaveBeenCalledWith('/personajes/7/oferta')
+    })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('shows error message when limit is reached', async () => {
+    const user = await setupWizard()
+
+    mockPost.mockImplementation((url) => {
+      if (url === '/characters') {
+        return Promise.reject({
+          response: {
+            status: 400,
+            data: { error: 'Ya alcanzaste el máximo de 3 personajes.' },
+          },
+        })
+      }
+      return Promise.resolve({ data: {} })
+    })
+
+    await user.click(screen.getByRole('button', { name: /confirmar y crear/i }))
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/characters', expect.any(Object))
+    })
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Ya alcanzaste el máximo de 3 personajes.')
+  })
+})

--- a/app/vitest.config.js
+++ b/app/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.js',
+  },
+})

--- a/app/vitest.setup.js
+++ b/app/vitest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/backend/controllers/__tests__/charactersController.test.js
+++ b/backend/controllers/__tests__/charactersController.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const Module = require('module')
+const originalLoad = Module._load
+
+Module._load = function (request, parent, isMain) {
+  if (request === 'sequelize') {
+    return { Op: {} }
+  }
+  if (request.endsWith('workers/equipPortrait')) {
+    return { enqueuePortraitRefresh: async () => {} }
+  }
+  if (request === 'bullmq') {
+    return {}
+  }
+  if (request === 'ioredis') {
+    return function MockRedis() {}
+  }
+  return originalLoad(request, parent, isMain)
+}
+
+const modelStub = {
+  Character: {
+    count: async () => 0,
+  },
+}
+
+require.cache[require.resolve('../../models')] = { exports: modelStub }
+
+const controller = require('../charactersController')
+
+const resetTestHarness = () => {
+  Module._load = originalLoad
+  modelStub.Character.count = async () => 0
+}
+
+const { hasReachedCharacterLimit, CHARACTER_LIMIT } = controller.__test__
+
+test('allows creation when below the limit', async () => {
+  modelStub.Character.count = async ({ where }) => {
+    assert.equal(where.userId, 1)
+    return CHARACTER_LIMIT - 1
+  }
+
+  const result = await hasReachedCharacterLimit(1)
+  assert.equal(result, false)
+})
+
+test('detects the limit when exactly at the cap', async () => {
+  modelStub.Character.count = async () => CHARACTER_LIMIT
+
+  const result = await hasReachedCharacterLimit(42)
+  assert.equal(result, true)
+})
+
+test('createCharacter returns 400 when limit reached', async () => {
+  modelStub.Character.count = async () => CHARACTER_LIMIT
+
+  const req = { user: { id: 99 }, body: { name: 'Test', raceId: 1, classId: 1 } }
+  let statusCode
+  let responseBody
+  const res = {
+    status(code) {
+      statusCode = code
+      return this
+    },
+    json(payload) {
+      responseBody = payload
+      return this
+    },
+  }
+
+  await controller.createCharacter(req, res, () => {})
+
+  assert.equal(statusCode, 400)
+  assert.deepEqual(responseBody, { error: 'Ya alcanzaste el máximo de 3 personajes.' })
+})
+
+test.after(resetTestHarness)


### PR DESCRIPTION
## Summary
- enforce a maximum of three characters per user before creating a new record and expose a reusable helper
- surface the limit error through the CreateCharacter flow and disable creation UI when the list already has three entries
- add backend and frontend tests plus Vitest configuration covering successful creation and limit rejection scenarios

## Testing
- node --test backend/controllers/__tests__/charactersController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dde409c67483299a5057dc2baaca83