### PR TITLE
Add explicit belongsTo relations for ability join tables

### DIFF
--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -83,9 +83,13 @@ Card.belongsTo(Ability, { foreignKey: "abilityId" });
 
 Class.belongsToMany(Ability, { through: ClassAbility, foreignKey: "classId" });
 Ability.belongsToMany(Class, { through: ClassAbility, foreignKey: "abilityId" });
+ClassAbility.belongsTo(Ability, { foreignKey: "abilityId" });
+ClassAbility.belongsTo(Class, { foreignKey: "classId" });
 
 Race.belongsToMany(Ability, { through: RaceAbility, foreignKey: "raceId" });
 Ability.belongsToMany(Race, { through: RaceAbility, foreignKey: "abilityId" });
+RaceAbility.belongsTo(Ability, { foreignKey: "abilityId" });
+RaceAbility.belongsTo(Race, { foreignKey: "raceId" });
 
 Talent.hasMany(Card, { foreignKey: "talentId" });
 Card.belongsTo(Talent, { foreignKey: "talentId" });


### PR DESCRIPTION
## Summary
- add belongsTo associations on ClassAbility and RaceAbility so the join models can be eagerly loaded

## Testing
- ⚠️ `node -e "const models=require('./backend/models'); console.log('Models loaded:', Object.keys(models));"` *(fails: missing sequelize module because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddee6eb6948329bb773660bd5eb756