### PR TITLE
Add equipped flag to character inventory

### DIFF
--- a/backend/migrations/20240821120000-add-equipped-to-character-inventory.js
+++ b/backend/migrations/20240821120000-add-equipped-to-character-inventory.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(
+      { tableName: 'character_inventory', schema: 'dwd' },
+      'equipped',
+      {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false
+      }
+    );
+
+    await queryInterface.sequelize.query(
+      'UPDATE "dwd"."character_inventory" SET "equipped" = false WHERE "equipped" IS NULL;'
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn(
+      { tableName: 'character_inventory', schema: 'dwd' },
+      'equipped'
+    );
+  }
+};


### PR DESCRIPTION
## Summary
- add a migration that introduces the equipped flag to dwd.character_inventory with a default of false
- ensure existing rows initialize the new column to false so filtering by equipped items keeps working

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddf528b94c8329ae4e7abe29b7c1a3